### PR TITLE
workdir access in the scripts and making sub-messages prettier

### DIFF
--- a/lib/xenuti/processor.rb
+++ b/lib/xenuti/processor.rb
@@ -84,7 +84,7 @@ class Xenuti::Processor
           fullpath = source
           fullpath = File.join(fullpath, relpath) unless relpath.empty?
           script_report = new_script_report(script, s_path, script_cfg, relpath)
-          execute_script(script, s_path, script_cfg['args'], script_report, fullpath)
+          execute_script(config, script, s_path, script_cfg['args'], script_report, fullpath)
           report['script_reports'] << script_report
         end
       end
@@ -93,14 +93,19 @@ class Xenuti::Processor
   # rubocop:enable MethodLength
 
   # rubocop:disable MethodLength
-  def self.execute_script(script_name, script_path, args, script_report, fullpath)
+  def self.execute_script(config, script_name, script_path, args, script_report, fullpath)
     script_report.scan_info.start_time = Time.now
     args = args.nil? ? '' : args.strip
 
     # execute script
     $log.info "Executing #{script_path} #{args} #{fullpath}"
+    #$log.info "Executing #{script_path} #{args}"
     output = ''
-    Open3.popen3("#{script_path} #{args} #{fullpath}") do |i, o, e|
+    #Open3.popen3("#{script_path} #{args} #{fullpath}") do |i, o, e|
+    
+    workdir = config['general']['workdir'].strip
+
+    Open3.popen3({"XENUTI_WORKDIR" => workdir},"#{script_path} #{args} #{fullpath}") do |i, o, e|
 
       # The goal of following is to stream output from stderr of the script
       # to out logger. We could just check: until e.eof? ... but trouble is

--- a/lib/xenuti/script_report.rb
+++ b/lib/xenuti/script_report.rb
@@ -104,7 +104,20 @@ class Xenuti::ScriptReport < Hash
   def format_message(message)
     return message if message.is_a? String
     if message.is_a? Array
-      return message.join("\n")
+      out = ''
+
+      # jechoi: Using JSON.pretty_generate() will improve the readability of Hash/Array type sub-messages
+      message.each {|m|
+        if m.is_a? Hash
+          out << JSON.pretty_generate(m)
+        elsif m.is_a? Array
+          out << JSON.pretty_generate(m)
+        else
+          out << m.to_s + "\n"
+        end
+      }
+      return out
+#     return message.join("\n")
     elsif message.is_a? Hash
       out = ''
       key_maxlen = message.key_maxlen + 1


### PR DESCRIPTION
1. workdir now can be referenced via XENUTI_WORKDIR in the scripts, 
2. Improved readability when sub-messages are HASH or Array in the report.
{"HASH1" => "VALUE1", "HASH2" => "VALUE2"}